### PR TITLE
add actions/checkout in gh release wf

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,6 +71,7 @@ jobs:
       contents: write  # IMPORTANT: mandatory for making GitHub Releases
       id-token: write  # IMPORTANT: mandatory for sigstore
     steps:
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Download all the dists
       uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
       with:


### PR DESCRIPTION
Fixes:
```
Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/platform/platform/.github/actions/sigstore'. Did you forget to run actions/checkout before running your local action?
```